### PR TITLE
Use backticks on command names for better readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ https://minikube.sigs.k8s.io/docs/start/
 
 Minikube provides a dashboard (web portal). Access the dashboard using the following command:
  
-minikube dashboard
+`minikube dashboard`
 
 ## Download this project
 
@@ -29,75 +29,75 @@ This project contains a web service coded in Java, but the language doesn't matt
 
 First of all, download and uncompress the project: https://github.com/charroux/kubernetes-minikube
 
-You can also use git: git clone https://github.com/charroux/kubernetes-minikube
+You can also use git: `git clone https://github.com/charroux/kubernetes-minikube`
 
-Then move to the sud directory with cd kubernetes-minikube/myservice where a DockerFile is.
+Then move to the sud directory with `cd kubernetes-minikube/myservice` where a DockerFile is.
 
 ## Test this project using Docker
 
 Compile the Java project: 
-* ./gradlew build   under Linux
-* gradlew build     under Windows
+* `./gradlew build`   under Linux
+* `gradlew build`     under Windows
 
-Build the docker image: docker build -t myservice .
+Build the docker image: `docker build -t myservice .`
 
-Check the image: docker images
+Check the image: `docker images`
 
-Start the container: docker run -p 4000:8080 -t myservice
+Start the container: `docker run -p 4000:8080 -t myservice`
 
 8080 is the port of the web service, while 4000 is the port for accessing the container. Test the web service using a web browser: http://localhost:4000 It displays hello.
 
-Ctr-c to stop the Web Service.
+Ctrl-C to stop the Web Service.
 
-Check the containerID: docker ps
+Check the containerID: `docker ps`
 
-Stop the container: docker stop containerID
+Stop the container: `docker stop containerID`
 
 ## Publish the image to the Docker Hub
 
-Retreive the image ID: docker images
+Retreive the image ID: `docker images`
 
-Tag the docker image: docker tag imageID yourDockerHubName/imageName:version
+Tag the docker image: `docker tag imageID yourDockerHubName/imageName:version`
 
-Example: docker tag 1dsd512s0d myDockerID/myservice:1
+Example: `docker tag 1dsd512s0d myDockerID/myservice:1`
 
 Login to docker hub: 
-* docker login      or
-* docker login http://hub.docker.com    or
-* docker login -u username -p password
+* `docker login`      or
+* `docker login http://hub.docker.com`    or
+* `docker login -u username -p password`
 
-Push the image to the docker hub: docker push yourDockerHubName/imageName:version
+Push the image to the docker hub: `docker push yourDockerHubName/imageName:version`
 
-Example: docker push myDockerID/myservice:1
+Example: `docker push myDockerID/myservice:1`
 
 ## Create a kubernetes deployment from a Docker image
 
-kubectl get nodes
+`kubectl get nodes`
 
-kubectl create deployment myservice --image=efrei/myservice:1 
+`kubectl create deployment myservice --image=efrei/myservice:1 `
 
 The image used comes from the Docker hub: https://hub.docker.com/r/efrei/myservice/tags
 
 But you can use your own image instead.
 
-Check the pod: kubectl get pods
+Check the pod: `kubectl get pods`
 
 Check if the state is running.
 
-Get complete logs for a pods: kubectl describe pods
+Get complete logs for a pods: `kubectl describe pods`
 
 Retreive the IP address but notice that this IP address is ephemeral since a pods can be deleted and replaced by a new one.
 
 Then retrieve the deployment in the minikube dashboard. 
 Actually the Docker container is runnung inside a Kubernetes pods (look at the pod in the dashboard).
   
-You can also enter inside the container in a interactive mode with: kubectl exec -it podname -- /bin/bash
+You can also enter inside the container in a interactive mode with: `kubectl exec -it podname -- /bin/bash`
 
-where podname is the name of the pods obtained with: kubectl get pods
+where podname is the name of the pods obtained with: `kubectl get pods`
 
-List the containt of the container with: ls
+List the containt of the container with: `ls`
 
-Don't forget to exit the container with: exit
+Don't forget to exit the container with: `exit`
 
 ## Expose the Deployment through a service
 
@@ -121,11 +121,11 @@ Type values and their behaviors are:
 
 ## Expose HTTP and HTTPS route using NodePort
 
-kubectl expose deployment myservice --type=NodePort --port=8080
+`kubectl expose deployment myservice --type=NodePort --port=8080`
 
-Retrieve the service address: minikube service myservice --url
+Retrieve the service address: `minikube service myservice --url`
 
-This format of this address is NodeIP:NodePort.
+This format of this address is `NodeIP:NodePort`.
 
 Test this address inside your browser. It should display hello again.
 
@@ -135,21 +135,21 @@ Look from the NodeIP and the NodePort in the minikube dashboard.
 
 Check if the myservice deployment is running:
 
-kubectl get deployments  
+`kubectl get deployments`  
 
 How many instance are actually running:
 
-kubectl get pods 
+`kubectl get pods` 
 
 Start a second instance:
 
-kubectl scale --replicas=2 deployment/myservice
+`kubectl scale --replicas=2 deployment/myservice`
 
-kubectl get deployments
+`kubectl get deployments`
 
 and 
 
-kubectl get pods 
+`kubectl get pods` 
 
 again
 
@@ -157,17 +157,17 @@ again
 
 Check if the myservice deployment is running:
 
-kubectl get deployments  
+`kubectl get deployments`  
 
-kubectl expose deployment myservice --type=LoadBalancer --port=8080
+`kubectl expose deployment myservice --type=LoadBalancer --port=8080`
 
-minikube service myservice --url
+`minikube service myservice --url`
 
 Test in your web browser
 
 ## Create a deployment and a service using a yaml file
 
-Yaml files can be used instead of using the command "kubectl create deployment" and "kubectl expose deployment"
+Yaml files can be used instead of using the command `kubectl create deployment` and `kubectl expose deployment`
 
 The yaml file for the deployment: https://github.com/charroux/kubernetes-minikube/blob/main/myservice-deployment.yml
 
@@ -175,13 +175,13 @@ The yaml file for the node port service: https://github.com/charroux/kubernetes-
 
 The yaml file for the node port service: https://github.com/charroux/kubernetes-minikube/blob/main/myservice-loadbalancing-service.yml
 
-Apply the deployment: kubectl apply -f myservice-deployment.yml
+Apply the deployment: `kubectl apply -f myservice-deployment.yml`
 
-Apply the node port service: kubectl apply -f myservice-service.yml
+Apply the node port service: `kubectl apply -f myservice-service.yml`
 
 or 
 
-Apply the service of type loadbalancer: kubectl apply -f myservice-loadbalancing-service.yml
+Apply the service of type loadbalancer: `kubectl apply -f myservice-loadbalancing-service.yml`
 
 Then test if it works as expected.
 
@@ -197,11 +197,11 @@ An Ingress may be configured to give Services externally-reachable URLs, load ba
 
 Enable the NGINX Ingress controller: 
 
-minikube addons enable ingress
+`minikube addons enable ingress`
 
 Verify that the NGINX Ingress controller is running:
 
-kubectl get pods -n kube-system
+`kubectl get pods -n kube-system`
 
 Create a Deployment and expose it as a NodePort (not a loadbalancer).
 
@@ -209,33 +209,35 @@ Check if it works.
 
 A yaml file for ingress: https://github.com/charroux/kubernetes-minikube/blob/main/ingress.yml
 
-kubectl apply -f ingress.yml 
+`kubectl apply -f ingress.yml` 
 
 Retrieve the IP address of Ingress: 
 
-kubectl get ingress
+`kubectl get ingress`
 
+```
 NAME                 CLASS    HOSTS                  ADDRESS        PORTS   AGE
 
 example-ingress      <none>   myservice.info         192.168.64.2   80      18m
+```
 
-On Linux: edit the /etc/hosts file and add at the bottom values for: 
+On Linux: edit the `/etc/hosts` file and add at the bottom values for: 
 
-ADDRESS     HOSTS
+`ADDRESS     HOSTS`
 
 Then check in your Web browser: 
 
 http://myservice.info/
 
-On Windows : edit the c:\windows\system32\drivers\etc\hosts file, add 
+On Windows : edit the `c:\windows\system32\drivers\etc\hosts` file, add 
 
-127.0.0.1 myservice.info	
+`127.0.0.1 myservice.info`	
 
 Enable a tunnel for Minikube:
 
-Minikube addons enable ingress-dns
+`minikube addons enable ingress-dns`
  
-minikube tunnel
+`minikube tunnel`
 
 Then check in your Web browser: 
 
@@ -246,8 +248,8 @@ Create a second deployment and its service, then add a new route to the ingress.
 
 ## Delete resources
 
-kubectl delete services myservice
+`kubectl delete services myservice`
 
-kubectl delete deployment myservice
+`kubectl delete deployment myservice`
 
 


### PR DESCRIPTION
Hello Sir,

I have added backtits (this character: \`) to improve the readability of some commands on the README file, `like this`. Indeed, some students did not clearly see the dot at the end of the docker build command.

Best regards,

Antoine DESPRES
M2 SE2